### PR TITLE
dist/tools/ci: toolchain versions: fix output to show avr-libc

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -43,7 +43,7 @@ function run {
     OUT_LENGTH="$(echo -n $OUT | wc -c)"
     if (( "$OUT_LENGTH" > 0 )); then
         echo -e "Command output:\n"
-        (printf "%s" "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
+        (echo "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
         echo ""
     fi
 }


### PR DESCRIPTION
use `echo` instead of `printf` to not consume last newline character